### PR TITLE
chore: Set Querydsl in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 plugins {
 	id 'org.springframework.boot' version '2.5.8'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	//querydsl 추가
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 	id 'java'
 }
 
@@ -22,6 +24,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'mysql:mysql-connector-java'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -38,3 +43,20 @@ test {
 jar {
 	enabled = false
 }
+
+//querydsl 추가 시작
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+//querydsl 추가 끝


### PR DESCRIPTION
## Q File 생성 방법
- Querydsl 을 사용하려면 Q + (Entity name) 파일을 통해서 사용하게 됩니다.
- QFile은 Github에 올려서 관리하는 파일이 아닌 시스템이 자동으로 생성해주기 때문에 Entity 생성마다 설정을 변경해주어야 합니다.

1. 작업중인 Local 환경의 build.gradle 파일에 Querydsl 설정이 잘 반영되었는지 확인합니다.
![image](https://user-images.githubusercontent.com/77976233/151691424-9e805ef1-904a-452b-8589-f8efa45e9e7a.png)
![image](https://user-images.githubusercontent.com/77976233/151691438-c0c0ffff-24e7-4184-9376-4b7047579b97.png)

2.  gradle 을 refresh 한 뒤 아래 사진에 나와있는 compilequerydsl을 더블 클릭 해줍니다.
![image](https://user-images.githubusercontent.com/77976233/151691482-d732b42a-426c-4d50-acf4-55fa2a737c87.png)

3. 이제 새로운 엔티티가 추가될 때마다 2번 항목을 반복해 로컬 환경에 QFile을 생성해 작업할 수 있습니다.